### PR TITLE
Added example for a simple vehicle use case

### DIFF
--- a/implementations/python/d3networking/transport/transport.py
+++ b/implementations/python/d3networking/transport/transport.py
@@ -95,6 +95,12 @@ class AvailablePayloadClient:
 
         return True
 
+    def close_connection(self):
+        """ Close the connection to the multicast group.
+        """
+        self._socket.shutdown()
+        self._socket.close()
+
     def recv_message(self, validate: bool = True) -> Union[AvailablePayloadMessage, None]:
         """ Receive a message on the UDP socket.
 

--- a/implementations/python/d3networking/vehicle/vehicle.py
+++ b/implementations/python/d3networking/vehicle/vehicle.py
@@ -1,0 +1,39 @@
+import datetime
+
+from ..transport.transport import AvailablePayloadClient, AvailablePayloadMessage
+
+
+def listen_for_drop_point_infos(nb_seconds: int) -> list[AvailablePayloadMessage]:
+    """
+    Listen for drop point infos from the server for a given amount of time.
+
+    :param nb_seconds: The number of seconds to listen for drop point infos.
+    """
+
+    # Start client on IPv6
+    validate_keys = []
+    client = AvailablePayloadClient(validate_keys, proto=6)
+
+    received_infos: dict[int, AvailablePayloadMessage] = {}
+
+    end_time = datetime.datetime.now() + datetime.timedelta(seconds=nb_seconds)
+    while datetime.datetime.now() <= end_time:
+        msg: AvailablePayloadMessage = client.recv_message(validate=False)
+        
+        # Check if message was received properly
+        if msg is None:
+            continue
+
+        # Check if message content is valid
+        if msg.team_id < 0 or msg.team_id > 99:
+            print("Invalid message content received")
+            continue
+        
+        received_infos[msg.team_id] = msg
+    
+    client.close_connection()
+
+    return list(received_infos.values())
+        
+
+        

--- a/implementations/python/examples/vehicle_main.py
+++ b/implementations/python/examples/vehicle_main.py
@@ -1,0 +1,24 @@
+""" Vehicle implementation for D3 networking
+
+Example of a vehicle implementation using the D3 networking library.
+"""
+from d3networking.message.message import AvailablePayloadMessage
+from d3networking.vehicle.vehicle import listen_for_drop_point_infos
+
+NB_SECONDS_TO_LISTEN = 3
+
+decision_picked = False
+while not decision_picked:
+    received_infos: list[AvailablePayloadMessage] = listen_for_drop_point_infos(NB_SECONDS_TO_LISTEN)
+    
+    if len(received_infos) == 0:
+        continue
+
+    # Example of a simple decision making process, we take the one with the max payload size
+    chosen_msg = max(received_infos, key=lambda msg: msg.payload_size)
+    print(f"Chosen drop point: ZC{chosen_msg.team_id}")
+    
+    # Exit the loop and let the vehicle go to the chosen drop point
+    decision_picked = True
+    
+


### PR DESCRIPTION
J'ai ajouté un package véhicule avec une seule méthode permettant d'écouter pendant un certain temps les différentes requêtes et qui retourne seulement les messages les plus récents recus.

Dans les exemples, j'ai ajouté un simple exemple d'utilisation dans le contexte du sous-système véhicule. De cette facon, chaque équipe véhicule pourra s'en inspirer

Note: Je n'ai pas inclus la validation des messages parce que comme discuté sur le Général du Teams de design3, la triche est interdite pour le projet